### PR TITLE
Fix installation directions

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -43,6 +43,7 @@ python -m pip install --upgrade pip
 
 ```bash
 pip install -f requirements.txt
+pip install cartopy
 ```
 
 or with conda:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cartopy==0.16.0
+#Cartopy==0.16.0
 click==6.7
 cycler==0.10.0
 Cython==0.28.5


### PR DESCRIPTION
Cartopy must be pip installed seperately, after ALL dependacies are satisfied.